### PR TITLE
fix: add builders to npm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "index.js",
   "files": [
     "index.js",
+    "builders.js",
     "src/"
   ],
   "scripts": {
@@ -115,8 +116,7 @@
       "path": "@semantic-release/commit-analyzer",
       "preset": "angular"
     },
-    "publish": [
-      {
+    "publish": [{
         "path": "@semantic-release/npm"
       },
       {


### PR DESCRIPTION
Missing change from https://github.com/flybondi/flynamo/pull/11