### PR TITLE
feat: add option to return the full dynamo response on query

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -12,8 +12,8 @@ const addTableName = require('./table-name');
 /**
  * @private
  */
-const createQuery = query => (params, options = {}) =>
-  query(params, options).then(options.raw ? unwrapOverAll('Items') : unwrapAll('Items'));
+const createQuery = query => (params, options) =>
+  query(params, options).then(options && options.raw ? unwrapOverAll('Items') : unwrapAll('Items'));
 
 /**
  * @private
@@ -43,8 +43,8 @@ function createQuerier(dynamoWrapper) {
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#API_Query_RequestSyntax
      * @param {Object} request Parameters as expected by DynamoDB `Query` operation. Must contain, at least, `TableName` attribute.
      * @param {Object=} options The configuration options parameters.
-     * @param {number} options.groupDelayMs The delay between individual requests. Defaults to 100 ms.
-     * @param {boolean} options.raw Wether to return the full DynamoDB response object when `true` or the `response.Items` property.
+     * @param {number=} options.groupDelayMs The delay between individual requests. Defaults to 100 ms.
+     * @param {boolean=} options.raw Whether to return the full DynamoDB response object when `true` or just the `Items` property value.
      * @returns {Promise} A promise that resolves to the response from DynamoDB.
      */
     query: createQuery(query),
@@ -84,8 +84,8 @@ function createQuerier(dynamoWrapper) {
      * @param {String} tableName The name of the table to perform the operation on
      * @param {Object=} request Parameters as expected by DynamoDB `Query` operation. A `TableName` attributes specified here will override `tableName` argument.
      * @param {Object=} options The configuration options parameters.
-     * @param {number} options.groupDelayMs The delay between individual requests. Defaults to 100 ms.
-     * @param {boolean} options.raw Wether to return the full DynamoDB response object when `true` or the `response.Items` property
+     * @param {number=} options.groupDelayMs The delay between individual requests. Defaults to 100 ms.
+     * @param {boolean=} options.raw Whether to return the full DynamoDB response object when `true` or just the `Items` property value.
      * @returns {Promise} A promise that resolves to the response from DynamoDB.
      */
     queryFor: createQueryFor(query)

--- a/src/query.js
+++ b/src/query.js
@@ -5,14 +5,15 @@
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html
  * @module Query
  */
-const { bind, pipeP, curry, compose } = require('ramda');
-const { unwrapAll } = require('./wrapper');
+const { bind, curry, compose } = require('ramda');
+const { unwrapAll, unwrapOverAll } = require('./wrapper');
 const addTableName = require('./table-name');
 
 /**
  * @private
  */
-const createQuery = query => pipeP(query, unwrapAll('Items'));
+const createQuery = query => (params, options = {}) =>
+  query(params, options).then(options.raw ? unwrapOverAll('Items') : unwrapAll('Items'));
 
 /**
  * @private
@@ -41,6 +42,9 @@ function createQuerier(dynamoWrapper) {
      *
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#API_Query_RequestSyntax
      * @param {Object} request Parameters as expected by DynamoDB `Query` operation. Must contain, at least, `TableName` attribute.
+     * @param {Object=} options The configuration options parameters.
+     * @param {number} options.groupDelayMs The delay between individual requests. Defaults to 100 ms.
+     * @param {boolean} options.raw Wether to return the full DynamoDB response object when `true` or the `response.Items` property.
      * @returns {Promise} A promise that resolves to the response from DynamoDB.
      */
     query: createQuery(query),
@@ -79,6 +83,9 @@ function createQuerier(dynamoWrapper) {
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#API_Query_RequestSyntax
      * @param {String} tableName The name of the table to perform the operation on
      * @param {Object=} request Parameters as expected by DynamoDB `Query` operation. A `TableName` attributes specified here will override `tableName` argument.
+     * @param {Object=} options The configuration options parameters.
+     * @param {number} options.groupDelayMs The delay between individual requests. Defaults to 100 ms.
+     * @param {boolean} options.raw Wether to return the full DynamoDB response object when `true` or the `response.Items` property
      * @returns {Promise} A promise that resolves to the response from DynamoDB.
      */
     queryFor: createQueryFor(query)

--- a/src/query.test.js
+++ b/src/query.test.js
@@ -37,7 +37,7 @@ describe('the queryFor function', () => {
       expect.objectContaining({
         TableName: 'some_table'
       }),
-      {}
+      undefined
     );
   });
 });

--- a/src/query.test.js
+++ b/src/query.test.js
@@ -20,6 +20,12 @@ describe('the query function', () => {
     const { query } = createQuerier({ query: mockQuery });
     expect(await query()).toEqual([{ foo: 'bar' }]);
   });
+
+  test('should return a full response object with the items unwrapped', async () => {
+    const mockQuery = jest.fn().mockResolvedValue({ Items: [{ foo: { S: 'bar' } }], Count: 1 });
+    const { query } = createQuerier({ query: mockQuery });
+    expect(await query({}, { raw: true })).toEqual({ Items: [{ foo: 'bar' }], Count: 1 });
+  });
 });
 
 describe('the queryFor function', () => {
@@ -30,7 +36,8 @@ describe('the queryFor function', () => {
     expect(mockQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         TableName: 'some_table'
-      })
+      }),
+      {}
     );
   });
 });

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -74,7 +74,7 @@ const safelyWrap = unless(
 );
 
 /**
- * Extracts an `Items` property containing an array or items aand unwraps all of them
+ * Extracts an `Items` property containing an array or items and unwraps all of them
  * by means of `AttributeValue.unwrap`.
  * If `Items` if either `null` or `undefined`, it returns the value as-is.
  *
@@ -112,6 +112,16 @@ const wrapProp = key => compose(safelyWrap, prop(key));
  */
 const unwrapOver = key => over(lensProp(key), safelyUnwrap);
 
+/**
+ * Returns a function that unwraps an object under a `key` property containing an array.
+ * It does not mutate the original object.
+ *
+ * @private
+ * @param {String} key The name of the prop to update
+ * @returns {Function}
+ */
+const unwrapOverAll = key => over(lensProp(key), map(safelyUnwrap));
+
 const unwrapProp = key => compose(safelyUnwrap, prop(key));
 
 module.exports = {
@@ -122,5 +132,6 @@ module.exports = {
   unwrapAll,
   wrapOver,
   wrapUpdatePut: safelyWrapUpdatePut,
-  unwrapOver
+  unwrapOver,
+  unwrapOverAll
 };


### PR DESCRIPTION
Added an `options.raw` property to the second query parameter in order to have a nice way to return the full DynamoDB response instead of only `response.Items`.