### PR TITLE
fix: replace `compose` with `useWith` in order to use the options argument in the query function. 

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -5,7 +5,7 @@
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html
  * @module Query
  */
-const { bind, curry, compose } = require('ramda');
+const { bind, curry, useWith } = require('ramda');
 const { unwrapAll, unwrapOverAll } = require('./wrapper');
 const addTableName = require('./table-name');
 
@@ -18,7 +18,7 @@ const createQuery = query => (params, options) =>
 /**
  * @private
  */
-const createQueryFor = curry((query, table) => compose(createQuery(query), addTableName(table)));
+const createQueryFor = curry((query, table) => useWith(createQuery(query), [addTableName(table)]));
 
 function createQuerier(dynamoWrapper) {
   const query = bind(dynamoWrapper.query, dynamoWrapper);

--- a/src/query.js
+++ b/src/query.js
@@ -5,7 +5,7 @@
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html
  * @module Query
  */
-const { bind, curry, useWith } = require('ramda');
+const { bind, curry } = require('ramda');
 const { unwrapAll, unwrapOverAll } = require('./wrapper');
 const addTableName = require('./table-name');
 
@@ -18,7 +18,11 @@ const createQuery = query => (params, options) =>
 /**
  * @private
  */
-const createQueryFor = curry((query, table) => useWith(createQuery(query), [addTableName(table)]));
+const createQueryFor = curry((query, table) => {
+  const queryFn = createQuery(query);
+  const withTableName = addTableName(table);
+  return (params, options) => queryFn(withTableName(params), options);
+});
 
 function createQuerier(dynamoWrapper) {
   const query = bind(dynamoWrapper.query, dynamoWrapper);

--- a/src/query.test.js
+++ b/src/query.test.js
@@ -40,4 +40,18 @@ describe('the queryFor function', () => {
       undefined
     );
   });
+
+  test('should create a query function with two arguments', async () => {
+    const mockQuery = jest.fn().mockResolvedValue({});
+    const { queryFor } = createQuerier({ query: mockQuery });
+    const query = queryFor('some_table');
+    await query({}, { raw: true });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: 'some_table'
+      }),
+      { raw: true }
+    );
+  });
 });

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -1,5 +1,5 @@
 'use strict';
-const { compose, prop, map, unless, when, isNil, over, lensProp } = require('ramda');
+const { compose, prop, map, unless, when, isNil, over, lensProp, propSatisfies } = require('ramda');
 const { AttributeValue, AttributeValueUpdate } = require('dynamodb-data-types');
 
 /**

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -121,7 +121,7 @@ const unwrapOver = key => over(lensProp(key), safelyUnwrap);
  * @returns {Function}
  */
 const unwrapOverAll = key =>
-  unless(compose(isNil, prop(key)), over(lensProp(key), map(safelyUnwrap)));
+  unless(propSatisfies(isNil, key), over(lensProp(key), map(safelyUnwrap)));
 
 const unwrapProp = key => compose(safelyUnwrap, prop(key));
 

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -120,7 +120,8 @@ const unwrapOver = key => over(lensProp(key), safelyUnwrap);
  * @param {String} key The name of the prop to update
  * @returns {Function}
  */
-const unwrapOverAll = key => over(lensProp(key), map(safelyUnwrap));
+const unwrapOverAll = key =>
+  unless(compose(isNil, prop(key)), over(lensProp(key), map(safelyUnwrap)));
 
 const unwrapProp = key => compose(safelyUnwrap, prop(key));
 


### PR DESCRIPTION
When creating the `query` fn with `queryFor` and using the resulting function as:

```js
const query = queryFor('table');
await query(params, { raw: true });
```

The `{ raw: true}` parameter never reach the function because of the `addTableName` function was running before and only accepts one parameter.

**Note**
```js
const createQueryFor = curry((query, table) => useWith(createQuery(query), [addTableName(table), identity]));
```

I did not use the `identity` function as the docs mentions to _keep arity or resulting function_ because the `useWith` creates a curry function that requires always two arguments in order to work as expecting.