### PR TITLE
fix: generate valid keys when Key attr is provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@types/aws-sdk": "^2.7.0",
+    "@types/jest": "^26.0.20",
     "aws-sdk": "^2.829.0",
     "docdash": "^1.2.0",
     "eslint": "^7.18.0",

--- a/src/client.js
+++ b/src/client.js
@@ -16,8 +16,8 @@ const DynamoDBWrapper = require('dynamodb-wrapper');
  *
  * @see https://github.com/Shadowblazen/dynamodb-wrapper#setup
  * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html
- * @param {import('aws-sdk').DynamoDB} client A DynamoDB client
- * @param {import('dynamodb-wrapper').IDynamoDBWrapperOptions} [config={}]  `DynamoDBWrapper` configuration (optional).
+ * @param {Object} client A DynamoDB client
+ * @param {Object} [config={}]  `DynamoDBWrapper` configuration (optional).
  */
 function flynamo(client, config = {}) {
   const clientWrapper = new DynamoDBWrapper(client, config);

--- a/src/generate-key.js
+++ b/src/generate-key.js
@@ -1,6 +1,6 @@
 'use strict';
-const { is, compose, unless, anyPass, isNil, has, objOf } = require('ramda');
-const { wrap } = require('./wrapper');
+const { is, compose, unless, isNil, has, objOf, either, propIs, prop, when } = require('ramda');
+const { wrapOver } = require('./wrapper');
 
 /**
  * Generates an object containing a `Key` property such as the one expected
@@ -14,13 +14,13 @@ const { wrap } = require('./wrapper');
  * @private
  * @example
  *  generateKey({ id: 'xYhd76' });
- *  // -> { Key: { id: 'xYhd76' } }
+ *  // -> { Key: { id: { S: 'xYhd76' } } }
  *
  *  generateKey(105);
- *  // -> { Key: { id: 105 } }
+ *  // -> { Key: { id: { N: '105' } } }
  *
  *  generateKey({ Key: { id: 'xYhd76' } });
- *  // -> { Key: { id: 'xYhd76' } }
+ *  // -> { Key: { id: { S: 'xYhd76' } } }
  *
  *  generateKey(undefined);
  *  // -> undefined
@@ -28,8 +28,14 @@ const { wrap } = require('./wrapper');
  * @returns {Object} An object containing a `Key` property.
  */
 const generateKey = unless(
-  anyPass([isNil, is(Function), has('Key')]),
-  compose(objOf('Key'), wrap, unless(is(Object), objOf('id')))
+  either(isNil, is(Function)),
+  compose(
+    wrapOver('Key'),
+    unless(
+      propIs(Object, 'Key'),
+      compose(objOf('Key'), unless(is(Object), objOf('id')), when(has('Key'), prop('Key')))
+    )
+  )
 );
 
 module.exports = generateKey;

--- a/src/generate-key.test.js
+++ b/src/generate-key.test.js
@@ -1,0 +1,36 @@
+'use strict';
+const generateKey = require('./generate-key');
+
+test('should return `null` if the input is `null`', () => {
+  expect(generateKey(null)).toBeNull();
+});
+
+test('should return `undefined` if the input is `undefined`', () => {
+  expect(generateKey(undefined)).toBeUndefined();
+});
+
+test('should assume a `Key` named `id` if a the input is a number', () => {
+  expect(generateKey(42)).toEqual({ Key: { id: { N: '42' } } });
+});
+
+test('should assume a `Key` named `id` if a the input is a string', () => {
+  expect(generateKey('foo')).toEqual({ Key: { id: { S: 'foo' } } });
+});
+
+test('should assume a `Key` named `id` if the input is an object containing a `Key` property which is a string', () => {
+  expect(generateKey({ Key: 'foo' })).toEqual({ Key: { id: { S: 'foo' } } });
+});
+
+test('should assume a `Key` named `id` if the input is an object containing a `Key` property which is a number', () => {
+  expect(generateKey({ Key: 42 })).toEqual({ Key: { id: { N: '42' } } });
+});
+
+test('should generate a full `Key` attribute value from the input if it is an object', () => {
+  expect(generateKey({ pk: 'foo', sk: 'bar' })).toEqual({
+    Key: { pk: { S: 'foo' }, sk: { S: 'bar' } }
+  });
+});
+
+test('should avoid adding a `Key` attribute if the input already defines one', () => {
+  expect(generateKey({ Key: { pk: 'foo' } })).toEqual({ Key: { pk: { S: 'foo' } } });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,6 +704,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^26.0.20":
+  version "26.0.20"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
+  integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -2861,7 +2869,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^26.6.2:
+jest-diff@^26.0.0, jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -4192,7 +4200,7 @@ prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
-pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==


### PR DESCRIPTION
> fixes #24 

- **fix**: `Key` attribute values are now generated properly when already providing `{ Key }` as input to relevant functions (e.g.: `await get({ Key: { id: 42 } });`.
- **docs**: `jsdoc` build should work again.